### PR TITLE
관계설정 책임 분리

### DIFF
--- a/src/main/java/com/toby/study/StudyApplication.java
+++ b/src/main/java/com/toby/study/StudyApplication.java
@@ -2,32 +2,16 @@ package com.toby.study;
 
 import com.toby.study.domain.dao.UserDao;
 import com.toby.study.domain.user.User;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import java.sql.SQLException;
 
-//@SpringBootApplication
+@SpringBootApplication
 public class StudyApplication {
 
 	public static void main(String[] args) throws SQLException, ClassNotFoundException {
-//		SpringApplication.run(StudyApplication.class, args);
-
-		UserDao dao = new UserDao();
-		User user = new User();
-
-		user.setId("1");
-		user.setName("박영재");
-		user.setPassword("1234");
-
-		// 등록
-		dao.add(user);
-		System.out.println(user.getId() + " 등록 성공");
-
-		// 	조회
-		User getUser = dao.get(user.getId());
-		System.out.println(getUser.getName());
-		System.out.println(getUser.getPassword());
-		System.out.println(getUser.getId() + " 조회 성공");
+		SpringApplication.run(StudyApplication.class, args);
 	}
-
 
 }

--- a/src/main/java/com/toby/study/domain/dao/UserDao.java
+++ b/src/main/java/com/toby/study/domain/dao/UserDao.java
@@ -18,8 +18,8 @@ public class UserDao {
 
     private ConnectionMaker simpleConnectionMaker;
 
-    public UserDao(){
-        simpleConnectionMaker = new DConnectionMaker();
+    public UserDao(ConnectionMaker connectionMaker){
+        simpleConnectionMaker = connectionMaker;
     }
 
     public void add(User user) throws ClassNotFoundException, SQLException {

--- a/src/main/java/com/toby/study/domain/test/UserDaoTest.java
+++ b/src/main/java/com/toby/study/domain/test/UserDaoTest.java
@@ -1,0 +1,31 @@
+package com.toby.study.domain.test;
+
+import com.toby.study.domain.dao.UserDao;
+import com.toby.study.domain.dao.connection.ConnectionMaker;
+import com.toby.study.domain.dao.connection.DConnectionMaker;
+import com.toby.study.domain.user.User;
+
+import java.sql.SQLException;
+
+public class UserDaoTest {
+    public static void main(String[] args) throws SQLException, ClassNotFoundException {
+        ConnectionMaker connectionMaker = new DConnectionMaker();
+
+        UserDao dao = new UserDao(connectionMaker);
+        User user = new User();
+
+        user.setId("1");
+        user.setName("박영재");
+        user.setPassword("1234");
+
+        // 등록
+        dao.add(user);
+        System.out.println(user.getId() + " 등록 성공");
+
+        // 	조회
+        User getUser = dao.get(user.getId());
+        System.out.println(getUser.getName());
+        System.out.println(getUser.getPassword());
+        System.out.println(getUser.getId() + " 조회 성공");
+    }
+}


### PR DESCRIPTION
인터페이스 분리로 결합도를 낮췄다고 생각했지만, 

UserDao의 생성자 내부에 ConnectionMaker의 구체 클래스를 명시해야 하기 때문에 , 이 책임을 다른 곳으로 옮겨 결합도를 낮추는 작업을 수행