### PR TITLE
UserDaoTest 오브젝트 구성 및 관계 정의 관심사 분리

### DIFF
--- a/src/main/java/com/toby/study/StudyApplication.java
+++ b/src/main/java/com/toby/study/StudyApplication.java
@@ -1,7 +1,5 @@
 package com.toby.study;
 
-import com.toby.study.domain.dao.UserDao;
-import com.toby.study.domain.user.User;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 

--- a/src/main/java/com/toby/study/connection/ConnectionMaker.java
+++ b/src/main/java/com/toby/study/connection/ConnectionMaker.java
@@ -1,4 +1,4 @@
-package com.toby.study.domain.dao.connection;
+package com.toby.study.connection;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -6,6 +6,6 @@ import java.sql.SQLException;
 
 public interface ConnectionMaker {
 
-    public Connection makeConnection() throws SQLException;
+    public Connection makeConnection() throws SQLException, ClassNotFoundException;
 
 }

--- a/src/main/java/com/toby/study/connection/DConnectionMaker.java
+++ b/src/main/java/com/toby/study/connection/DConnectionMaker.java
@@ -1,4 +1,4 @@
-package com.toby.study.domain.dao.connection;
+package com.toby.study.connection;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -6,7 +6,9 @@ import java.sql.SQLException;
 
 public class DConnectionMaker implements ConnectionMaker{
     @Override
-    public Connection makeConnection() throws SQLException {
+    public Connection makeConnection() throws SQLException, ClassNotFoundException {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+
         String url = "jdbc:mysql://localhost:3306/studyToby";
         String dbUser = "root";
         String pw = "12345678";

--- a/src/main/java/com/toby/study/dao/UserDao.java
+++ b/src/main/java/com/toby/study/dao/UserDao.java
@@ -1,7 +1,6 @@
-package com.toby.study.domain.dao;
+package com.toby.study.dao;
 
-import com.toby.study.domain.dao.connection.ConnectionMaker;
-import com.toby.study.domain.dao.connection.DConnectionMaker;
+import com.toby.study.connection.ConnectionMaker;
 import com.toby.study.domain.user.User;
 
 import java.sql.*;
@@ -23,9 +22,6 @@ public class UserDao {
     }
 
     public void add(User user) throws ClassNotFoundException, SQLException {
-        // 동적으로 클래스 정보를 가져온다.
-        Class.forName("com.mysql.cj.jdbc.Driver");
-        
         // DB 연결을 위한 커넥션을 가져온다.
         Connection c = simpleConnectionMaker.makeConnection();
 
@@ -45,9 +41,6 @@ public class UserDao {
     }
 
     public User get(String id) throws ClassNotFoundException, SQLException {
-        // 동적으로 클래스 정보를 가져온다.
-        Class.forName("com.mysql.cj.jdbc.Driver");
-
         // DB 연결을 위한 커넥션을 가져온다.
         Connection c = simpleConnectionMaker.makeConnection();
 

--- a/src/main/java/com/toby/study/factory/DaoFactory.java
+++ b/src/main/java/com/toby/study/factory/DaoFactory.java
@@ -1,0 +1,18 @@
+package com.toby.study.factory;
+
+import com.toby.study.connection.ConnectionMaker;
+import com.toby.study.connection.DConnectionMaker;
+import com.toby.study.dao.UserDao;
+
+/**
+ * UserDao 와 ConnectionFactory 오브젝트들을 구성하고 관계를 정의하는 책임이 있음
+ */
+public class DaoFactory {
+
+    public UserDao userDao(){
+        ConnectionMaker con = new DConnectionMaker();
+        UserDao userDao = new UserDao(con);
+
+        return userDao;
+    }
+}

--- a/src/main/java/com/toby/study/test/UserDaoTest.java
+++ b/src/main/java/com/toby/study/test/UserDaoTest.java
@@ -1,9 +1,10 @@
-package com.toby.study.domain.test;
+package com.toby.study.test;
 
-import com.toby.study.domain.dao.UserDao;
-import com.toby.study.domain.dao.connection.ConnectionMaker;
-import com.toby.study.domain.dao.connection.DConnectionMaker;
+import com.toby.study.dao.UserDao;
+import com.toby.study.connection.ConnectionMaker;
+import com.toby.study.connection.DConnectionMaker;
 import com.toby.study.domain.user.User;
+import com.toby.study.factory.DaoFactory;
 
 import java.sql.SQLException;
 
@@ -11,7 +12,7 @@ public class UserDaoTest {
     public static void main(String[] args) throws SQLException, ClassNotFoundException {
         ConnectionMaker connectionMaker = new DConnectionMaker();
 
-        UserDao dao = new UserDao(connectionMaker);
+        UserDao userDao = new DaoFactory().userDao();
         User user = new User();
 
         user.setId("1");
@@ -19,11 +20,11 @@ public class UserDaoTest {
         user.setPassword("1234");
 
         // 등록
-        dao.add(user);
+        userDao.add(user);
         System.out.println(user.getId() + " 등록 성공");
 
         // 	조회
-        User getUser = dao.get(user.getId());
+        User getUser = userDao.get(user.getId());
         System.out.println(getUser.getName());
         System.out.println(getUser.getPassword());
         System.out.println(getUser.getId() + " 조회 성공");


### PR DESCRIPTION
UserDaoTest는 오브젝트 간 관계 설정에 대한 로직을 떠넘겨 받았고, 

기존에 테스트 목적으로 만든 UserDaoTest의 목적을 살리기 위해 떠넘겨 받은 오브젝트 간 관계 설정은 DaoFactory 클래스로 분리했다.